### PR TITLE
Update methods.jl

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -12,7 +12,7 @@ type LazyMethod{T}
     ast::Expr
     source::String
     funcheader::String
-    LazyMethod(signature, cache = Dict()) = new{T}(signature, cache, OrderedSet(), OrderedSet{LazyMethod}())
+    (::Type{LazyMethod{T}})(signature, cache = Dict()) = new{T}(signature, cache, OrderedSet(), OrderedSet{LazyMethod}())
 end
 
 LazyMethod(signature) = LazyMethod{:JL}(signature)

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -12,7 +12,7 @@ type LazyMethod{T}
     ast::Expr
     source::String
     funcheader::String
-    (::Type{LazyMethod{T}})(signature, cache = Dict()) = new{T}(signature, cache, OrderedSet(), OrderedSet{LazyMethod}())
+    (::Type{LazyMethod{T}}){T}(signature, cache = Dict()) = new{T}(signature, cache, OrderedSet(), OrderedSet{LazyMethod}())
 end
 
 LazyMethod(signature) = LazyMethod{:JL}(signature)


### PR DESCRIPTION
The very ugly way of  `LazyMethod{T}(...) where T ...`   avoiding dep warnings on 0.6 and having it compatible with 0.5  .... please squash