### PR TITLE
[WIP] Fixing errors for Julia 0.7

### DIFF
--- a/src/Sugar.jl
+++ b/src/Sugar.jl
@@ -2,6 +2,8 @@ __precompile__(true)
 module Sugar
 
 using Matcha, MacroTools, DataStructures, Compat
+import Base: LabelNode, GotoNode, CodeInfo, TypedSlot, Slot, SSAValue, SlotNumber, NewvarNode
+import InteractiveUtils
 
 const AllFuncs = Union{Function, Core.Builtin, Core.IntrinsicFunction}
 const IntrinsicFuncs = Union{Core.Builtin, Core.IntrinsicFunction}

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -39,7 +39,7 @@ LazyMethod(f, types) = LazyMethod{:JL}((f, Base.to_tuple_type(types)))
 Like @code_typed, but will create a lazymethod!
 """
 macro lazymethod(ex0)
-    :($(Base.gen_call_with_extracted_types(Base, :LazyMethod, ex0)))
+    :($(InteractiveUtils.gen_call_with_extracted_types(Base, :LazyMethod, ex0)))
 end
 
 

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -146,9 +146,9 @@ function (pat::MTMatchFun)(expr)
     end
 end
 
-struct FrameBuffer{N, ElTypes}
-    buffers::NTuple{N, <: Texture}
-end
+# struct FrameBuffer{N, ElTypes}
+#     buffers::NTuple{N, <: Texture}
+# end
 
 
 function mt_match(patterns::Vector)


### PR DESCRIPTION
Little by little, I'm fixing errors in `sd/07` branch according to the latest Julia master. You can find a couple of changes below, but there's much more to do. Things I don't know how to fix:

 - [ ] I  can't figure out what is `Texture` in the definition of `FrameBuffer`, and can't find any usage example for the latter; I've commented it out for now
 - [x] `jl_get_julia_home` isn't available anymore, which breaks `juliabasepath` and eventually `get_source_at`